### PR TITLE
feat: Change xatu event Implementation field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 # Any go workspace files a user may have created.
 go.work
 go.work.sum
+
+# Contributoor
+config.yaml
+dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,9 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w -X github.com/ethpandaops/contributoor/internal/contributoor.Release={{.Tag}} -X github.com/ethpandaops/contributoor/internal/contributoor.GitCommit={{.ShortCommit}} -X github.com/ethpandaops/contributoor/internal/contributoor.GOOS={{.Os}} -X github.com/ethpandaops/contributoor/internal/contributoor.GOARCH={{.Arch}}
+    mod_timestamp: "{{ .CommitTimestamp }}"
 
 dockers:
   - image_templates:

--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ethpandaops/contributoor/internal/clockdrift"
+	contr "github.com/ethpandaops/contributoor/internal/contributoor"
 	"github.com/ethpandaops/contributoor/internal/events"
 	"github.com/ethpandaops/contributoor/internal/sinks"
 	"github.com/ethpandaops/contributoor/pkg/config/v1"
@@ -76,6 +77,8 @@ func main() {
 				"config_path": s.config.ContributoorDirectory,
 				"name":        s.name,
 				"version":     s.config.Version,
+				"commit":      contr.GitCommit,
+				"release":     contr.Release,
 			}).Info("Starting contributoor")
 
 			if err := s.initClockDrift(ctx); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.0
-	github.com/prysmaticlabs/go-bitfield v0.0.0-20240328144219-a1caa50c3a1e
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.5
@@ -151,6 +150,7 @@ require (
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/prysmaticlabs/fastssz v0.0.0-20241008181541-518c4ce73516 // indirect
+	github.com/prysmaticlabs/go-bitfield v0.0.0-20240328144219-a1caa50c3a1e // indirect
 	github.com/prysmaticlabs/gohashtree v0.0.4-beta.0.20240624100937-73632381301b // indirect
 	github.com/prysmaticlabs/prysm/v5 v5.1.0 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect

--- a/internal/contributoor/contributoor.go
+++ b/internal/contributoor/contributoor.go
@@ -1,0 +1,38 @@
+package contributoor
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/ethpandaops/xatu/pkg/proto/xatu"
+)
+
+var (
+	Release        = "dev"
+	GitCommit      = "dev"
+	Implementation = "Contributoor"
+	GOOS           = runtime.GOOS
+	GOARCH         = runtime.GOARCH
+	Module         = xatu.ModuleName_SENTRY
+)
+
+func Full() string {
+	return fmt.Sprintf("%s/%s", Implementation, Short())
+}
+
+func Short() string {
+	return fmt.Sprintf("%s-%s", Release, GitCommit)
+}
+
+func FullVWithGOOS() string {
+	return fmt.Sprintf("%s/%s", Full(), GOOS)
+}
+
+func FullVWithPlatform() string {
+	return fmt.Sprintf("%s/%s/%s", Full(), GOOS, GOARCH)
+}
+
+func ImplementationLower() string {
+	return strings.ToLower(Implementation)
+}

--- a/pkg/ethereum/beacon.go
+++ b/pkg/ethereum/beacon.go
@@ -10,6 +10,7 @@ import (
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/ethpandaops/beacon/pkg/beacon"
 	"github.com/ethpandaops/contributoor/internal/clockdrift"
+	"github.com/ethpandaops/contributoor/internal/contributoor"
 	"github.com/ethpandaops/contributoor/internal/events"
 	v1 "github.com/ethpandaops/contributoor/internal/events/v1"
 	"github.com/ethpandaops/contributoor/internal/sinks"
@@ -411,10 +412,10 @@ func (b *BeaconNode) createEventMeta(ctx context.Context) (*xatu.Meta, error) {
 	return &xatu.Meta{
 		Client: &xatu.ClientMeta{
 			Name:           clientName,
-			Version:        xatu.Short(),
+			Version:        contributoor.Short(),
 			Id:             uuid.New().String(),
-			Implementation: xatu.Implementation,
-			ModuleName:     xatu.ModuleName_SENTRY,
+			Implementation: contributoor.Implementation,
+			ModuleName:     contributoor.Module,
 			Os:             runtime.GOOS,
 			ClockDrift:     uint64(b.clockDrift.GetDrift().Milliseconds()),
 			Ethereum: &xatu.ClientMeta_Ethereum{


### PR DESCRIPTION
- Swaps the `Implementation` meta on all events from `Xatu` to `Contributoor`
- added commit/release fields from `contributoor` - these were previously using the version from the Xatu package