### PR TITLE
fix(build): use multi-platform build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ dockers:
     dockerfile: Dockerfile
     use: buildx
     build_flag_templates:
-      - "--platform=linux/amd64"
+      - "--platform=linux/amd64,linux/arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
     extra_files:


### PR DESCRIPTION
Missing `arm`. Use multi-platform build.

https://docs.docker.com/build/building/multi-platform/