### PR TITLE
ci: Update golangci-lint-action version and arguments

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,5 +13,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: golangci/golangci-lint-action@v3 
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest
+          args: --timeout=10m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,21 +10,7 @@ permissions:
   packages: write
 
 jobs:
-  go-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/workflows/go-setup
-      - run: go test -v -race ./...
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: golangci/golangci-lint-action@v3
-
   goreleaser:
-    needs: [go-test, lint]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
- Sporadically seeing a few lint timeouts, default is 1m. Pretty common practice to have to bump this, its a beast.
- Saves some trees, don't re-run tests/lint on release, would've been covered by PRs.
