### PR TITLE
feat: Disable non mainline networks

### DIFF
--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -499,12 +499,18 @@ func applyConfigOverridesFromFlags(cfg *config.Config, c *cli.Context) error {
 	// Apply environment variables first, then override with CLI flags if set
 	if network := os.Getenv("CONTRIBUTOOR_NETWORK"); network != "" {
 		log.Infof("Setting network from env to %s", network)
-		cfg.SetNetwork(network)
+
+		if err := cfg.SetNetwork(network); err != nil {
+			return errors.Wrap(err, "failed to set network from env")
+		}
 	}
 
 	if c.String("network") != "" {
 		log.Infof("Overriding network from CLI to %s", c.String("network"))
-		cfg.SetNetwork(c.String("network"))
+
+		if err := cfg.SetNetwork(c.String("network")); err != nil {
+			return errors.Wrap(err, "failed to set network from cli")
+		}
 	}
 
 	if addr := os.Getenv("CONTRIBUTOOR_BEACON_NODE_ADDRESS"); addr != "" {

--- a/cmd/sentry/main_test.go
+++ b/cmd/sentry/main_test.go
@@ -316,8 +316,12 @@ func TestConfigOverridePrecedence(t *testing.T) {
 			expectedValue: "holesky",
 			envVar:        "CONTRIBUTOOR_NETWORK",
 			cliFlag:       "network",
-			setter:        func(c *config.Config, v string) { c.SetNetwork(v) },
-			getter:        func(c *config.Config) string { return strings.ToLower(c.NetworkName.DisplayName()) },
+			setter: func(c *config.Config, v string) {
+				if err := c.SetNetwork(v); err != nil {
+					t.Fatalf("failed to set network: %v", err)
+				}
+			},
+			getter: func(c *config.Config) string { return strings.ToLower(c.NetworkName.DisplayName()) },
 		},
 		{
 			name:          "Env overrides config but not CLI - beacon node",

--- a/pkg/config/v1/config.go
+++ b/pkg/config/v1/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net"
 	"net/url"
 	"os"
@@ -164,9 +166,9 @@ func (c *Config) GetHealthCheckHostPort() (host, port string) {
 }
 
 // SetNetwork sets the network name.
-func (c *Config) SetNetwork(network string) {
+func (c *Config) SetNetwork(network string) error {
 	if network == "" {
-		return
+		return errors.New("network is required")
 	}
 
 	switch strings.ToLower(network) {
@@ -176,7 +178,11 @@ func (c *Config) SetNetwork(network string) {
 		c.NetworkName = NetworkName_NETWORK_NAME_SEPOLIA
 	case "holesky":
 		c.NetworkName = NetworkName_NETWORK_NAME_HOLESKY
+	default:
+		return fmt.Errorf("invalid network: %s", network)
 	}
+
+	return nil
 }
 
 // SetBeaconNodeAddress sets the beacon node address.


### PR DESCRIPTION
Other networks don't work at the moment, and setting `--network=pectra-devnet-6` will incorrectly send data off with `network=mainnet`, so let's just disable it for now until we can come back to supporting custom networks