### PR TITLE
feat: Derive network details from spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ go.work.sum
 # Contributoor
 config.yaml
 dist
+
+.vscode

--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -599,8 +599,7 @@ func (s *contributoor) initBeacon(
 		log,
 		traceID,
 		&ethereum.Config{
-			BeaconNodeAddress:   address,
-			OverrideNetworkName: strings.ToLower(s.config.NetworkName.DisplayName()),
+			BeaconNodeAddress: address,
 		},
 		sinks,
 		s.clockDrift,

--- a/pkg/ethereum/beacon.go
+++ b/pkg/ethereum/beacon.go
@@ -390,15 +390,13 @@ func (b *BeaconNode) createEventMeta(ctx context.Context) (*xatu.Meta, error) {
 	var networkMeta *xatu.ClientMeta_Ethereum_Network
 
 	network := b.metadataSvc.Network
-	if network != nil {
-		networkMeta = &xatu.ClientMeta_Ethereum_Network{
-			Name: string(network.Name),
-			Id:   network.ID,
-		}
+	if network == nil {
+		return nil, errors.New("network is unknown")
+	}
 
-		if b.config.OverrideNetworkName != "" {
-			networkMeta.Name = b.config.OverrideNetworkName
-		}
+	networkMeta = &xatu.ClientMeta_Ethereum_Network{
+		Name: string(network.Name),
+		Id:   network.ID,
 	}
 
 	hashed, err := b.metadataSvc.NodeIDHash()

--- a/pkg/ethereum/beacon.go
+++ b/pkg/ethereum/beacon.go
@@ -102,7 +102,7 @@ func NewBeaconNode(
 	}, "contributoor", opts)
 
 	// Initialize services.
-	metadata := services.NewMetadataService(log, node, config.OverrideNetworkName)
+	metadata := services.NewMetadataService(log, node)
 
 	return &BeaconNode{
 		log:         log,

--- a/pkg/ethereum/config.go
+++ b/pkg/ethereum/config.go
@@ -8,9 +8,6 @@ import (
 type Config struct {
 	// The address of the Beacon node to connect to
 	BeaconNodeAddress string `yaml:"beaconNodeAddress"`
-	// OverrideNetworkName is the name of the network to use for the sentry.
-	// If not set, the network name will be retrieved from the beacon node.
-	OverrideNetworkName string `yaml:"overrideNetworkName"  default:""`
 	// BeaconNodeHeaders is a map of headers to send to the beacon node.
 	BeaconNodeHeaders map[string]string `yaml:"beaconNodeHeaders"`
 	// BeaconSubscriptions is a list of beacon subscriptions to subscribe to.

--- a/pkg/ethereum/networks/networks.go
+++ b/pkg/ethereum/networks/networks.go
@@ -1,0 +1,110 @@
+package networks
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethpandaops/beacon/pkg/beacon/state"
+)
+
+type NetworkName string
+
+type Network struct {
+	Name                   NetworkName
+	ID                     uint64
+	DepositContractAddress string
+	DepositChainID         uint64
+}
+
+var (
+	NetworkNameUnknown NetworkName = "unknown"
+	NetworkNameMainnet NetworkName = "mainnet"
+	NetworkNameSepolia NetworkName = "sepolia"
+	NetworkNameHolesky NetworkName = "holesky"
+	NetworkNameHoodi   NetworkName = "hoodi"
+)
+
+var (
+	ErrNetworkNotFound = errors.New("network not found")
+)
+
+var (
+	// KnownNetworks is a list of known networks with their deposit contract addresses and deposit network IDs that
+	// contributoor supports.
+	KnownNetworks = []Network{
+		{
+			Name:                   NetworkNameMainnet,
+			ID:                     1,
+			DepositContractAddress: "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+			DepositChainID:         1,
+		},
+		{
+			Name:                   NetworkNameSepolia,
+			ID:                     11155111,
+			DepositContractAddress: "0x7f02c3e3c98b133055b8b348b2ac625669ed295d",
+			DepositChainID:         11155111,
+		},
+		{
+			Name:                   NetworkNameHolesky,
+			ID:                     17000,
+			DepositContractAddress: "0x4242424242424242424242424242424242424242",
+			DepositChainID:         17000,
+		},
+		{
+			Name:                   NetworkNameHoodi,
+			ID:                     560048,
+			DepositContractAddress: "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+			DepositChainID:         560048,
+		},
+	}
+)
+
+// DeriveFromSpec derives a network from a spec.
+// If the deposit contract address and chain ID aren't known by contributoor, then
+// it attempts to derive the network name from the CONFIG_NAME.
+// If this CONFIG_NAME is one of our known networks, then we return an error.
+// This ensures that we:
+// - We have safety garauntees for our defined networks
+// - We still support networks that are not in our list of known networks
+func DeriveFromSpec(spec *state.Spec) (*Network, error) {
+	for _, network := range KnownNetworks {
+		if network.DepositContractAddress == spec.DepositContractAddress && network.DepositChainID == spec.DepositChainID {
+			return &network, nil
+		}
+	}
+
+	// Attempt to support networks that are not in our list of known networks
+	// by using the spec config name.
+	if spec.ConfigName != "" {
+		// Check if the spec config name is one of our known networks
+		if _, err := FindByName(NetworkName(spec.ConfigName)); err == nil {
+			// We've somehow found a network that is not in our list of known networks
+			// but the CONFIG_NAME matches one of our known networks
+			// We'll return an error here to ensure that we don't send incorrect network information.
+			// Realistically, this should never happen.
+			return nil, fmt.Errorf("%w: %s", ErrNetworkNotFound, spec.ConfigName)
+		}
+
+		// The spec config name is not one of our known networks, so we'll return the network
+		// with the given deposit contract address and chain ID.
+		return &Network{
+			Name:                   NetworkName(spec.ConfigName),
+			ID:                     spec.DepositChainID,
+			DepositContractAddress: spec.DepositContractAddress,
+			DepositChainID:         spec.DepositChainID,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("%w: %s", ErrNetworkNotFound, spec.ConfigName)
+}
+
+// FindByName returns a network with the given name or an error if not found
+func FindByName(name NetworkName) (*Network, error) {
+	for _, network := range KnownNetworks {
+		if network.Name == name {
+			return &network, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%w: %s", ErrNetworkNotFound, name)
+}

--- a/pkg/ethereum/networks/networks.go
+++ b/pkg/ethereum/networks/networks.go
@@ -3,6 +3,7 @@ package networks
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/ethpandaops/beacon/pkg/beacon/state"
 )
@@ -68,7 +69,8 @@ var (
 // - We still support networks that are not in our list of known networks
 func DeriveFromSpec(spec *state.Spec) (*Network, error) {
 	for _, network := range KnownNetworks {
-		if network.DepositContractAddress == spec.DepositContractAddress && network.DepositChainID == spec.DepositChainID {
+		if strings.ToLower(network.DepositContractAddress) == strings.ToLower(spec.DepositContractAddress) &&
+			network.DepositChainID == spec.DepositChainID {
 			return &network, nil
 		}
 	}
@@ -82,7 +84,7 @@ func DeriveFromSpec(spec *state.Spec) (*Network, error) {
 			// but the CONFIG_NAME matches one of our known networks
 			// We'll return an error here to ensure that we don't send incorrect network information.
 			// Realistically, this should never happen.
-			return nil, fmt.Errorf("%w: %s", ErrNetworkNotFound, spec.ConfigName)
+			return nil, fmt.Errorf("incorrect network detected: %s", spec.ConfigName)
 		}
 
 		// The spec config name is not one of our known networks, so we'll return the network

--- a/pkg/ethereum/networks/networks.go
+++ b/pkg/ethereum/networks/networks.go
@@ -66,10 +66,10 @@ var (
 // If this CONFIG_NAME is one of our known networks, then we return an error.
 // This ensures that we:
 // - We have safety garauntees for our defined networks
-// - We still support networks that are not in our list of known networks
+// - We still support networks that are not in our list of known networks.
 func DeriveFromSpec(spec *state.Spec) (*Network, error) {
 	for _, network := range KnownNetworks {
-		if strings.ToLower(network.DepositContractAddress) == strings.ToLower(spec.DepositContractAddress) &&
+		if strings.EqualFold(network.DepositContractAddress, spec.DepositContractAddress) &&
 			network.DepositChainID == spec.DepositChainID {
 			return &network, nil
 		}
@@ -100,7 +100,7 @@ func DeriveFromSpec(spec *state.Spec) (*Network, error) {
 	return nil, fmt.Errorf("%w: %s", ErrNetworkNotFound, spec.ConfigName)
 }
 
-// FindByName returns a network with the given name or an error if not found
+// FindByName returns a network with the given name or an error if not found.
 func FindByName(name NetworkName) (*Network, error) {
 	for _, network := range KnownNetworks {
 		if network.Name == name {

--- a/pkg/ethereum/networks/networks_test.go
+++ b/pkg/ethereum/networks/networks_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Mock state.Spec for testing
+// Mock state.Spec for testing.
 func createMockSpec(depositContractAddress string, depositChainID uint64, configName string) *state.Spec {
 	return &state.Spec{
 		DepositContractAddress: depositContractAddress,
@@ -71,6 +71,16 @@ func TestDeriveFromSpec(t *testing.T) {
 			},
 		},
 		{
+			name: "mainnet with lowercase address",
+			spec: createMockSpec("0x00000000219ab540356cbb839cbe05303d7705fa", 1, "mainnet"),
+			expectedNetwork: &Network{
+				Name:                   NetworkNameMainnet,
+				ID:                     1,
+				DepositContractAddress: "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+				DepositChainID:         1,
+			},
+		},
+		{
 			name: "sepolia",
 			spec: createMockSpec("0x7f02c3e3c98b133055b8b348b2ac625669ed295d", 11155111, "sepolia"),
 			expectedNetwork: &Network{
@@ -118,7 +128,7 @@ func TestDeriveFromSpec(t *testing.T) {
 		{
 			name:                  "conflicting config name",
 			spec:                  createMockSpec("0x1111111111111111111111111111111111111111", 123456, "mainnet"),
-			expectedErrorContains: "network not found",
+			expectedErrorContains: "incorrect network detected",
 		},
 	}
 

--- a/pkg/ethereum/networks/networks_test.go
+++ b/pkg/ethereum/networks/networks_test.go
@@ -1,0 +1,200 @@
+package networks
+
+import (
+	"testing"
+
+	"github.com/ethpandaops/beacon/pkg/beacon/state"
+	"github.com/stretchr/testify/assert"
+)
+
+// Mock state.Spec for testing
+func createMockSpec(depositContractAddress string, depositChainID uint64, configName string) *state.Spec {
+	return &state.Spec{
+		DepositContractAddress: depositContractAddress,
+		DepositChainID:         depositChainID,
+		ConfigName:             configName,
+	}
+}
+
+func TestNetworkConstants(t *testing.T) {
+	// Verify network name constants
+	assert.Equal(t, NetworkName("unknown"), NetworkNameUnknown)
+	assert.Equal(t, NetworkName("mainnet"), NetworkNameMainnet)
+	assert.Equal(t, NetworkName("sepolia"), NetworkNameSepolia)
+	assert.Equal(t, NetworkName("holesky"), NetworkNameHolesky)
+	assert.Equal(t, NetworkName("hoodi"), NetworkNameHoodi)
+}
+
+func TestKnownNetworks(t *testing.T) {
+	// Verify KnownNetworks has the expected number of entries
+	assert.Len(t, KnownNetworks, 4)
+
+	// Verify specific network properties
+	mainnetFound := false
+	holeskiFound := false
+
+	for _, network := range KnownNetworks {
+		if network.Name == NetworkNameMainnet {
+			mainnetFound = true
+			assert.Equal(t, uint64(1), network.ID)
+			assert.Equal(t, "0x00000000219ab540356cBB839Cbe05303d7705Fa", network.DepositContractAddress)
+			assert.Equal(t, uint64(1), network.DepositChainID)
+		}
+
+		if network.Name == NetworkNameHolesky {
+			holeskiFound = true
+			assert.Equal(t, uint64(17000), network.ID)
+			assert.Equal(t, "0x4242424242424242424242424242424242424242", network.DepositContractAddress)
+			assert.Equal(t, uint64(17000), network.DepositChainID)
+		}
+	}
+
+	assert.True(t, mainnetFound, "Mainnet network not found in KnownNetworks")
+	assert.True(t, holeskiFound, "Holesky network not found in KnownNetworks")
+}
+
+func TestDeriveFromSpec(t *testing.T) {
+	tests := []struct {
+		name                  string
+		spec                  *state.Spec
+		expectedNetwork       *Network
+		expectedErrorContains string
+	}{
+		{
+			name: "mainnet",
+			spec: createMockSpec("0x00000000219ab540356cBB839Cbe05303d7705Fa", 1, "mainnet"),
+			expectedNetwork: &Network{
+				Name:                   NetworkNameMainnet,
+				ID:                     1,
+				DepositContractAddress: "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+				DepositChainID:         1,
+			},
+		},
+		{
+			name: "sepolia",
+			spec: createMockSpec("0x7f02c3e3c98b133055b8b348b2ac625669ed295d", 11155111, "sepolia"),
+			expectedNetwork: &Network{
+				Name:                   NetworkNameSepolia,
+				ID:                     11155111,
+				DepositContractAddress: "0x7f02c3e3c98b133055b8b348b2ac625669ed295d",
+				DepositChainID:         11155111,
+			},
+		},
+		{
+			name: "holesky",
+			spec: createMockSpec("0x4242424242424242424242424242424242424242", 17000, "holesky"),
+			expectedNetwork: &Network{
+				Name:                   NetworkNameHolesky,
+				ID:                     17000,
+				DepositContractAddress: "0x4242424242424242424242424242424242424242",
+				DepositChainID:         17000,
+			},
+		},
+		{
+			name: "hoodi",
+			spec: createMockSpec("0x00000000219ab540356cBB839Cbe05303d7705Fa", 560048, "hoodi"),
+			expectedNetwork: &Network{
+				Name:                   NetworkNameHoodi,
+				ID:                     560048,
+				DepositContractAddress: "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+				DepositChainID:         560048,
+			},
+		},
+		{
+			name:                  "unknown network with no config name",
+			spec:                  createMockSpec("0x1111111111111111111111111111111111111111", 123456, ""),
+			expectedErrorContains: "network not found",
+		},
+		{
+			name: "unknown network with custom config name",
+			spec: createMockSpec("0x1111111111111111111111111111111111111111", 123456, "custom-testnet"),
+			expectedNetwork: &Network{
+				Name:                   "custom-testnet",
+				ID:                     123456,
+				DepositContractAddress: "0x1111111111111111111111111111111111111111",
+				DepositChainID:         123456,
+			},
+		},
+		{
+			name:                  "conflicting config name",
+			spec:                  createMockSpec("0x1111111111111111111111111111111111111111", 123456, "mainnet"),
+			expectedErrorContains: "network not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			network, err := DeriveFromSpec(tt.spec)
+
+			if tt.expectedErrorContains != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrorContains)
+				assert.Nil(t, network)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedNetwork.Name, network.Name)
+				assert.Equal(t, tt.expectedNetwork.ID, network.ID)
+				assert.Equal(t, tt.expectedNetwork.DepositContractAddress, network.DepositContractAddress)
+				assert.Equal(t, tt.expectedNetwork.DepositChainID, network.DepositChainID)
+			}
+		})
+	}
+}
+
+func TestFindByName(t *testing.T) {
+	tests := []struct {
+		name                  string
+		networkName           NetworkName
+		expectedNetwork       *Network
+		expectedErrorContains string
+	}{
+		{
+			name:        "mainnet",
+			networkName: NetworkNameMainnet,
+			expectedNetwork: &Network{
+				Name:                   NetworkNameMainnet,
+				ID:                     1,
+				DepositContractAddress: "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+				DepositChainID:         1,
+			},
+		},
+		{
+			name:        "sepolia",
+			networkName: NetworkNameSepolia,
+			expectedNetwork: &Network{
+				Name:                   NetworkNameSepolia,
+				ID:                     11155111,
+				DepositContractAddress: "0x7f02c3e3c98b133055b8b348b2ac625669ed295d",
+				DepositChainID:         11155111,
+			},
+		},
+		{
+			name:                  "unknown network",
+			networkName:           "invalid-network",
+			expectedErrorContains: "network not found",
+		},
+		{
+			name:                  "unknown network with value",
+			networkName:           NetworkNameUnknown,
+			expectedErrorContains: "network not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			network, err := FindByName(tt.networkName)
+
+			if tt.expectedErrorContains != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrorContains)
+				assert.Nil(t, network)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedNetwork.Name, network.Name)
+				assert.Equal(t, tt.expectedNetwork.ID, network.ID)
+				assert.Equal(t, tt.expectedNetwork.DepositContractAddress, network.DepositContractAddress)
+				assert.Equal(t, tt.expectedNetwork.DepositChainID, network.DepositChainID)
+			}
+		})
+	}
+}

--- a/pkg/ethereum/services/metadata.go
+++ b/pkg/ethereum/services/metadata.go
@@ -71,8 +71,6 @@ func (m *MetadataService) Start(ctx context.Context) error {
 			}).Fatal("Failed to derive network")
 		}
 
-		m.log.Info("Beacon node is running on network: %s", m.Network.Name)
-
 		if err := m.Ready(ctx); err != nil {
 			m.log.WithError(err).Warn("Failed to check metadata service readiness")
 		}

--- a/pkg/ethereum/services/metadata.go
+++ b/pkg/ethereum/services/metadata.go
@@ -211,6 +211,12 @@ func (m *MetadataService) DeriveNetwork(_ context.Context) error {
 		return errors.New("spec is not available")
 	}
 
+	m.log.WithFields(logrus.Fields{
+		"deposit_contract_address": m.Spec.DepositContractAddress,
+		"deposit_chain_id":         m.Spec.DepositChainID,
+		"config_name":              m.Spec.ConfigName,
+	}).Info("Deriving ethereum network")
+
 	network, err := networks.DeriveFromSpec(m.Spec)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR is the first step in automatically deriving the network from the beacon node instead of relying on config.

- Check the `DEPOSIT_CONTRACT_ADDRESS` and `DEPOSIT_CHAIN_ID` from `/eth/v1/config/spec`
  - If the network is one of our "known" networks, we're good
  - Otherwise, use the `CONFIG_NAME` as the network name.
    - If the `CONFIG_NAME` matches one of our "known" networks, we'll exit
- If we can't derive a network name, fatally error