### PR TITLE
feat(events): sanity check slot on event - data integrity

### DIFF
--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -26,6 +26,9 @@ type BeaconDataProvider interface {
 	Synced(ctx context.Context) error
 	// Node returns the underlying beacon node instance.
 	Node() beacon.Node
+	// IsSlotFromUnexpectedNetwork checks if a slot appears to be from an unexpected network
+	// by comparing it with the current wallclock slot.
+	IsSlotFromUnexpectedNetwork(eventSlot uint64) bool
 }
 
 // Event is the interface that all events must implement.

--- a/internal/events/mock/beacon_data_provider.mock.go
+++ b/internal/events/mock/beacon_data_provider.mock.go
@@ -98,6 +98,20 @@ func (mr *MockBeaconDataProviderMockRecorder) GetWallclock() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWallclock", reflect.TypeOf((*MockBeaconDataProvider)(nil).GetWallclock))
 }
 
+// IsSlotFromUnexpectedNetwork mocks base method.
+func (m *MockBeaconDataProvider) IsSlotFromUnexpectedNetwork(eventSlot uint64) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSlotFromUnexpectedNetwork", eventSlot)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSlotFromUnexpectedNetwork indicates an expected call of IsSlotFromUnexpectedNetwork.
+func (mr *MockBeaconDataProviderMockRecorder) IsSlotFromUnexpectedNetwork(eventSlot any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSlotFromUnexpectedNetwork", reflect.TypeOf((*MockBeaconDataProvider)(nil).IsSlotFromUnexpectedNetwork), eventSlot)
+}
+
 // Node mocks base method.
 func (m *MockBeaconDataProvider) Node() beacon.Node {
 	m.ctrl.T.Helper()

--- a/internal/events/v1/blob_sidecar.go
+++ b/internal/events/v1/blob_sidecar.go
@@ -108,6 +108,13 @@ func (e *BlobSidecarEvent) Ignore(ctx context.Context) (bool, error) {
 		return true, err
 	}
 
+	// Check if event is from an unexpected network based on slot
+	if e.beacon.IsSlotFromUnexpectedNetwork(uint64(e.data.Slot)) {
+		e.log.WithField("slot", e.data.Slot).Warn("Ignoring blob sidecar event from unexpected network")
+
+		return true, nil
+	}
+
 	hash, err := hashstructure.Hash(e.data, hashstructure.FormatV2, nil)
 	if err != nil {
 		return true, err

--- a/internal/events/v1/blob_sidecar_test.go
+++ b/internal/events/v1/blob_sidecar_test.go
@@ -120,8 +120,27 @@ func TestBlobSidecarEvent_Ignore(t *testing.T) {
 		require.True(t, ignore)
 	})
 
+	t.Run("unexpected network", func(t *testing.T) {
+		mockBeacon.EXPECT().Synced(gomock.Any()).Return(nil)
+		mockBeacon.EXPECT().IsSlotFromUnexpectedNetwork(slot).Return(true)
+
+		event := NewBlobSidecarEvent(
+			logrus.New(),
+			mockBeacon,
+			cache,
+			&xatu.Meta{Client: &xatu.ClientMeta{}},
+			blobSidecar,
+			now,
+		)
+
+		ignore, err := event.Ignore(context.Background())
+		require.NoError(t, err)
+		require.True(t, ignore)
+	})
+
 	t.Run("cache hit", func(t *testing.T) {
 		mockBeacon.EXPECT().Synced(gomock.Any()).Return(nil).Times(2)
+		mockBeacon.EXPECT().IsSlotFromUnexpectedNetwork(slot).Return(false).Times(2)
 
 		event := NewBlobSidecarEvent(
 			logrus.New(),

--- a/internal/events/v1/block.go
+++ b/internal/events/v1/block.go
@@ -106,6 +106,13 @@ func (e *BlockEvent) Ignore(ctx context.Context) (bool, error) {
 		return true, err
 	}
 
+	// Check if event is from an unexpected network based on slot
+	if e.beacon.IsSlotFromUnexpectedNetwork(uint64(e.data.Slot)) {
+		e.log.WithField("slot", e.data.Slot).Warn("Ignoring block event from unexpected network")
+
+		return true, nil
+	}
+
 	hash, err := hashstructure.Hash(e.data, hashstructure.FormatV2, nil)
 	if err != nil {
 		return true, err

--- a/internal/events/v1/block_test.go
+++ b/internal/events/v1/block_test.go
@@ -106,8 +106,27 @@ func TestBlockEvent_Ignore(t *testing.T) {
 		require.True(t, ignore)
 	})
 
+	t.Run("unexpected network", func(t *testing.T) {
+		mockBeacon.EXPECT().Synced(gomock.Any()).Return(nil)
+		mockBeacon.EXPECT().IsSlotFromUnexpectedNetwork(slot).Return(true)
+
+		event := NewBlockEvent(
+			logrus.New(),
+			mockBeacon,
+			cache,
+			&xatu.Meta{Client: &xatu.ClientMeta{}},
+			block,
+			now,
+		)
+
+		ignore, err := event.Ignore(context.Background())
+		require.NoError(t, err)
+		require.True(t, ignore)
+	})
+
 	t.Run("cache hit", func(t *testing.T) {
 		mockBeacon.EXPECT().Synced(gomock.Any()).Return(nil).Times(2)
+		mockBeacon.EXPECT().IsSlotFromUnexpectedNetwork(slot).Return(false).Times(2)
 
 		event := NewBlockEvent(
 			logrus.New(),

--- a/internal/events/v1/chain_reorg.go
+++ b/internal/events/v1/chain_reorg.go
@@ -102,6 +102,13 @@ func (e *ChainReorgEvent) Ignore(ctx context.Context) (bool, error) {
 		return true, err
 	}
 
+	// Check if event is from an unexpected network based on slot
+	if e.beacon.IsSlotFromUnexpectedNetwork(uint64(e.data.Slot)) {
+		e.log.WithField("slot", e.data.Slot).Warn("Ignoring chain reorg event from unexpected network")
+
+		return true, nil
+	}
+
 	hash, err := hashstructure.Hash(e.data, hashstructure.FormatV2, nil)
 	if err != nil {
 		return true, err

--- a/internal/events/v1/chain_reorg_test.go
+++ b/internal/events/v1/chain_reorg_test.go
@@ -118,8 +118,27 @@ func TestChainReorgEvent_Ignore(t *testing.T) {
 		require.True(t, ignore)
 	})
 
+	t.Run("unexpected network", func(t *testing.T) {
+		mockBeacon.EXPECT().Synced(gomock.Any()).Return(nil)
+		mockBeacon.EXPECT().IsSlotFromUnexpectedNetwork(slot).Return(true)
+
+		event := NewChainReorgEvent(
+			logrus.New(),
+			mockBeacon,
+			cache,
+			&xatu.Meta{Client: &xatu.ClientMeta{}},
+			reorg,
+			now,
+		)
+
+		ignore, err := event.Ignore(context.Background())
+		require.NoError(t, err)
+		require.True(t, ignore)
+	})
+
 	t.Run("cache hit", func(t *testing.T) {
 		mockBeacon.EXPECT().Synced(gomock.Any()).Return(nil).Times(2)
+		mockBeacon.EXPECT().IsSlotFromUnexpectedNetwork(slot).Return(false).Times(2)
 
 		event := NewChainReorgEvent(
 			logrus.New(),

--- a/internal/events/v1/head.go
+++ b/internal/events/v1/head.go
@@ -108,6 +108,13 @@ func (e *HeadEvent) Ignore(ctx context.Context) (bool, error) {
 		return true, err
 	}
 
+	// Check if event is from an unexpected network based on slot
+	if e.beacon.IsSlotFromUnexpectedNetwork(uint64(e.data.Slot)) {
+		e.log.WithField("slot", e.data.Slot).Warn("Ignoring head event from unexpected network")
+
+		return true, nil
+	}
+
 	hash, err := hashstructure.Hash(e.data, hashstructure.FormatV2, nil)
 	if err != nil {
 		return true, err

--- a/internal/events/v1/head_test.go
+++ b/internal/events/v1/head_test.go
@@ -108,8 +108,27 @@ func TestHeadEvent_Ignore(t *testing.T) {
 		require.True(t, ignore)
 	})
 
+	t.Run("unexpected network", func(t *testing.T) {
+		mockBeacon.EXPECT().Synced(gomock.Any()).Return(nil)
+		mockBeacon.EXPECT().IsSlotFromUnexpectedNetwork(slot).Return(true)
+
+		event := NewHeadEvent(
+			logrus.New(),
+			mockBeacon,
+			cache,
+			&xatu.Meta{Client: &xatu.ClientMeta{}},
+			head,
+			now,
+		)
+
+		ignore, err := event.Ignore(context.Background())
+		require.NoError(t, err)
+		require.True(t, ignore)
+	})
+
 	t.Run("cache hit", func(t *testing.T) {
 		mockBeacon.EXPECT().Synced(gomock.Any()).Return(nil).Times(2)
+		mockBeacon.EXPECT().IsSlotFromUnexpectedNetwork(slot).Return(false).Times(2)
 
 		event := NewHeadEvent(
 			logrus.New(),

--- a/pkg/ethereum/beacon.go
+++ b/pkg/ethereum/beacon.go
@@ -27,7 +27,7 @@ import (
 // MaxReasonableSlotDifference is the maximum number of slots that can be
 // between the event slot and the current slot before we consider the event
 // to be from a different network.
-const MaxReasonableSlotDifference uint64 = 32
+const MaxReasonableSlotDifference uint64 = 10000
 
 // BeaconNodeAPI is the interface for the BeaconNode.
 type BeaconNodeAPI interface {

--- a/pkg/ethereum/beacon_test.go
+++ b/pkg/ethereum/beacon_test.go
@@ -1,0 +1,60 @@
+package ethereum
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSlotDifferenceTooLarge(t *testing.T) {
+	tests := []struct {
+		name           string
+		slotA          uint64
+		slotB          uint64
+		expectTooLarge bool
+	}{
+		{
+			name:           "identical slots",
+			slotA:          100,
+			slotB:          100,
+			expectTooLarge: false,
+		},
+		{
+			name:           "within threshold (positive direction)",
+			slotA:          100,
+			slotB:          120, // 20 slot difference
+			expectTooLarge: false,
+		},
+		{
+			name:           "within threshold (negative direction)",
+			slotA:          120,
+			slotB:          100, // 20 slot difference
+			expectTooLarge: false,
+		},
+		{
+			name:           "at threshold",
+			slotA:          100,
+			slotB:          132, // exactly 32 slot difference
+			expectTooLarge: false,
+		},
+		{
+			name:           "beyond threshold (positive direction)",
+			slotA:          100,
+			slotB:          140, // 40 slot difference, > MaxReasonableSlotDifference (32)
+			expectTooLarge: true,
+		},
+		{
+			name:           "beyond threshold (negative direction)",
+			slotA:          140,
+			slotB:          100, // 40 slot difference, > MaxReasonableSlotDifference (32)
+			expectTooLarge: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isSlotDifferenceTooLarge(tt.slotA, tt.slotB)
+			assert.Equal(t, tt.expectTooLarge, result)
+		})
+	}
+}

--- a/pkg/ethereum/beacon_test.go
+++ b/pkg/ethereum/beacon_test.go
@@ -20,33 +20,33 @@ func TestIsSlotDifferenceTooLarge(t *testing.T) {
 			expectTooLarge: false,
 		},
 		{
-			name:           "within threshold (positive direction)",
+			name:           "small difference (positive direction)",
 			slotA:          100,
-			slotB:          120, // 20 slot difference
+			slotB:          1000, // 900 slot difference
 			expectTooLarge: false,
 		},
 		{
-			name:           "within threshold (negative direction)",
-			slotA:          120,
-			slotB:          100, // 20 slot difference
+			name:           "small difference (negative direction)",
+			slotA:          1000,
+			slotB:          100, // 900 slot difference
 			expectTooLarge: false,
 		},
 		{
 			name:           "at threshold",
 			slotA:          100,
-			slotB:          132, // exactly 32 slot difference
+			slotB:          10100, // exactly 10000 slot difference
 			expectTooLarge: false,
 		},
 		{
 			name:           "beyond threshold (positive direction)",
 			slotA:          100,
-			slotB:          140, // 40 slot difference, > MaxReasonableSlotDifference (32)
+			slotB:          12000, // 11900 slot difference, > MaxReasonableSlotDifference (10000)
 			expectTooLarge: true,
 		},
 		{
 			name:           "beyond threshold (negative direction)",
-			slotA:          140,
-			slotB:          100, // 40 slot difference, > MaxReasonableSlotDifference (32)
+			slotA:          12000,
+			slotB:          100, // 11900 slot difference, > MaxReasonableSlotDifference (10000)
 			expectTooLarge: true,
 		},
 	}


### PR DESCRIPTION
When a user restarts their beacon node connected to a different network (e.g., switching from Mainnet to Holesky), contributoor continues processing events with the original network metadata. This leads to contaminated data being sent to Xatu, as events from different networks get recorded with incorrect network identification.

Utilising the existing `Ignore()` methods for events, this PR adds validation to check if an event's slot is too far from the expected slot based on the current wallclock. If the slot difference exceeds 32 slots, the event is considered to be from an unexpected network and is ignored.