### PR TITLE
feat(manual-telegram-notify.yml): allow specifying topic ID for release notifications

### DIFF
--- a/.github/workflows/manual-telegram-notify.yml
+++ b/.github/workflows/manual-telegram-notify.yml
@@ -10,6 +10,11 @@ on:
         description: 'Additional custom message (optional)'
         required: false
         type: string
+      topic_id:
+        description: 'Topic ID for the message (e.g. 1 = General, 2 = Announcements, 114 = Releases)'
+        required: false
+        type: string
+        default: '114'
 
 permissions:
   contents: read
@@ -31,22 +36,37 @@ jobs:
           echo "RELEASE_BODY<<EOF" >> $GITHUB_OUTPUT
           echo "$(echo $RELEASE_DATA | jq -r '.body')" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+      
+      - name: Determine topic ID
+        id: topic
+        run: |
+          TOPIC_ID="${{ github.event.inputs.topic_id }}"
+          if [ -z "$TOPIC_ID" ]; then
+            TOPIC_ID="${{ secrets.TELEGRAM_TOPIC_ID }}"
+          fi
+          echo "id=$TOPIC_ID" >> $GITHUB_OUTPUT
+          echo "Using topic ID: $TOPIC_ID"
 
-      - name: Send Telegram notification for releases
-        uses: appleboy/telegram-action@master
-        with:
-          to: ${{ secrets.TELEGRAM_TO }}
-          token: ${{ secrets.TELEGRAM_TOKEN }}
-          message_thread_id: ${{ secrets.TELEGRAM_TOPIC_ID }}
-          message: |
-            🚀 New Release: *${{ github.repository }}* ${{ github.event.inputs.release_tag }}
-            
-            📝 Release Title: ${{ steps.release_info.outputs.RELEASE_NAME }}
-            
-            ${{ steps.release_info.outputs.RELEASE_BODY }}
-            
-            ${{ github.event.inputs.custom_message }}
-            
-            [View Release](https://github.com/${{ github.repository }}/releases/tag/${{ github.event.inputs.release_tag }})
-          format: markdown
-          disable_web_page_preview: true 
+      - name: Send notification using Telegram API directly
+        run: |
+          MESSAGE="🚀 *New Release*: *${{ github.repository }}* ${{ github.event.inputs.release_tag }}
+
+          📝 *Release Title*: ${{ steps.release_info.outputs.RELEASE_NAME }}
+          
+          ${{ steps.release_info.outputs.RELEASE_BODY }}
+          
+          ${{ github.event.inputs.custom_message }}
+          
+          [View Release](https://github.com/${{ github.repository }}/releases/tag/${{ github.event.inputs.release_tag }})"
+          
+          # Debug info
+          echo "Sending to chat ID: ${{ secrets.TELEGRAM_TO }}"
+          echo "Using topic ID: ${{ steps.topic.outputs.id }}"
+          
+          # Send message
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_TOKEN }}/sendMessage" \
+            -d "chat_id=${{ secrets.TELEGRAM_TO }}" \
+            -d "message_thread_id=${{ steps.topic.outputs.id }}" \
+            -d "text=$MESSAGE" \
+            -d "parse_mode=Markdown" \
+            -d "disable_web_page_preview=true" | jq 


### PR DESCRIPTION
This commit introduces the ability to specify a topic ID for release notifications sent to Telegram.

The changes include:

- Added an input field `topic_id` to the workflow, allowing users to specify the Telegram topic ID when manually triggering the workflow.
- Added a step to determine the topic ID, prioritizing the input value, then the `TELEGRAM_TOPIC_ID` secret, and defaulting to '114' (Releases).
- Modified the Telegram notification step to use the determined topic ID when sending the message.
- Changed the telegram action to use curl command to be able to specify topic id.