### PR TITLE
chore: replace renovate with dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+   - package-ecosystem: github-actions
+     directory: /
+     schedule:
+        interval: weekly
+     groups:
+        actions:
+           patterns:
+              - '*'
+   - package-ecosystem: gomod
+     directory: /
+     schedule:
+        interval: weekly
+     groups:
+        go-dependencies:
+           patterns:
+              - '*'

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
-}


### PR DESCRIPTION
This commit replaces Renovate with Dependabot for managing dependency updates. Dependabot is configured to update GitHub Actions and Go module dependencies weekly.
Renovate configuration file is removed.