### PR TITLE
feat(client.go): add Caplin consensus client

### DIFF
--- a/pkg/ethereum/services/client.go
+++ b/pkg/ethereum/services/client.go
@@ -21,6 +21,8 @@ const (
 	ClientLodestar Client = "lodestar"
 	// ClientGrandine represents the Grandine consensus client.
 	ClientGrandine Client = "grandine"
+	// ClientCaplin represents the Caplin consensus client.
+	ClientCaplin Client = "caplin"
 )
 
 // AllClients contains all known consensus client implementations.
@@ -32,6 +34,7 @@ var AllClients = []Client{
 	ClientPrysm,
 	ClientLodestar,
 	ClientGrandine,
+	ClientCaplin,
 }
 
 // clientIdentifiers maps client-specific strings to their respective Client type.
@@ -42,6 +45,7 @@ var clientIdentifiers = map[string]Client{
 	"prysm":      ClientPrysm,
 	"lodestar":   ClientLodestar,
 	"grandine":   ClientGrandine,
+	"caplin":     ClientCaplin,
 }
 
 // ClientFromString identifies a consensus client from a string identifier.


### PR DESCRIPTION
This commit introduces the Caplin consensus client to the list of supported clients. It includes:

- Adding `ClientCaplin` to the `Client` type.
- Adding `ClientCaplin` to the `AllClients` list.
- Mapping the string "caplin" to `ClientCaplin` in the `clientIdentifiers` map.

This change allows the system to recognize and interact with the Caplin consensus client.