### PR TITLE
fix(go.mod): replace go-eth2-client with PK's fork to support EIP-7805

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/ethpandaops/contributoor
 
 go 1.24.1
 
+// Use PK's fork supporting eip-7805 spec, until upstream is updated (https://github.com/pk910/go-eth2-client/pull/3)
+replace github.com/attestantio/go-eth2-client => github.com/pk910/go-eth2-client v0.0.0-20250515124841-1d7c6ee326e4
+
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250425153114-8976f5be98c1.1
 	github.com/attestantio/go-eth2-client v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOL
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
-github.com/attestantio/go-eth2-client v0.25.0 h1:wLQxoteGCbTE/vKCMASx1ze+Zm9rcqtltRnblaLJup4=
-github.com/attestantio/go-eth2-client v0.25.0/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
 github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 h1:zAybnyUQXIZ5mok5Jqwlf58/TFE7uvd3IAsa1aF9cXs=
@@ -467,6 +465,8 @@ github.com/pion/webrtc/v4 v4.0.13 h1:XuUaWTjRufsiGJRC+G71OgiSMe7tl7mQ0kkd4bAqIaQ
 github.com/pion/webrtc/v4 v4.0.13/go.mod h1:Fadzxm0CbY99YdCEfxrgiVr0L4jN1l8bf8DBkPPpJbs=
 github.com/pk910/dynamic-ssz v0.0.6 h1:Tu97LSc2TtCyqRfoSbhG9XuR/FbA7CkKeAnlkgUydFY=
 github.com/pk910/dynamic-ssz v0.0.6/go.mod h1:b6CrLaB2X7pYA+OSEEbkgXDEcRnjLOZIxZTsMuO/Y9c=
+github.com/pk910/go-eth2-client v0.0.0-20250515124841-1d7c6ee326e4 h1:riGVTN/A3PQsSD1+D0PM0s5QQuP8ksPTV5mKhiPmLlA=
+github.com/pk910/go-eth2-client v0.0.0-20250515124841-1d7c6ee326e4/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
Teku update preset config to include array BLOB_SCHEDULE's in 25.5.

**Kurtosis test:**

```yaml
participants:
  - el_type: geth
    cl_type: teku
    cl_image: consensys/teku:25.5
  - el_type: nethermind
    cl_type: teku
    cl_image: consensys/teku:25.5
network_params:
  network: "mainnet"
```

**Before:**

```bash
INFO[0000] Starting contributoor                         commit=dev config_path=/Users/matty/.contributoor module=contributoor release=dev version=0.0.64
INFO[0000] Initializing beacons                          addresses="[http://127.0.0.1:33001]" count=1 module=contributoor trace_ids="[bn_74191]"
INFO[0000] Batch item processor initialized              batch_timeout=5s export_timeout=30s max_export_batch_size=512 max_queue_size=51200 module=contributoor shipping_method=async trace_id=bn_74191 workers=5
INFO[0000] Enabling keepalive                            keepalive_time=2m30s keepalive_timeout=30s module=contributoor output_name=bn_74191 output_type=xatu trace_id=bn_74191
INFO[0000] Batch item processor initialized              batch_timeout=5s export_timeout=30s max_export_batch_size=512 max_queue_size=51200 module=contributoor shipping_method=async trace_id=bn_74191 workers=1
INFO[0000] Starting 5 workers for xatu_output_stdout_bn_74191  module=contributoor trace_id=bn_74191
INFO[0000] Starting 1 workers for xatu_output_xatu_bn_74191  module=contributoor trace_id=bn_74191
ERRO[0000] Failed to start beacon node                   error="failed to unmarshal data\njson: cannot unmarshal array into Go value of type string" module=consensus/beacon
^CINFO[0009] Received shutdown signal
INFO[0009] Context cancelled, starting shutdown          module=contributoor
INFO[0009] Stopping beacon node                          module=contributoor trace_id=bn_74191
INFO[0009] Stopping service                              module=contributoor service=metadata trace_id=bn_74191
INFO[0009] Stopping stdout sink                          module=contributoor trace_id=bn_74191
INFO[0009] Stopping xatu sink                            module=contributoor trace_id=bn_74191
INFO[0009] Shutdown complete                             module=contributoor
```

**After:**
```bash
INFO[0000] Starting contributoor                         commit=dev config_path=/Users/matty/.contributoor module=contributoor release=dev version=0.0.64
INFO[0000] Initializing beacons                          addresses="[http://127.0.0.1:33001]" count=1 module=contributoor trace_ids="[bn_74191]"
INFO[0000] Batch item processor initialized              batch_timeout=5s export_timeout=30s max_export_batch_size=512 max_queue_size=51200 module=contributoor shipping_method=async trace_id=bn_74191 workers=5
INFO[0000] Enabling keepalive                            keepalive_time=2m30s keepalive_timeout=30s module=contributoor output_name=bn_74191 output_type=xatu trace_id=bn_74191
INFO[0000] Batch item processor initialized              batch_timeout=5s export_timeout=30s max_export_batch_size=512 max_queue_size=51200 module=contributoor shipping_method=async trace_id=bn_74191 workers=1
INFO[0000] Starting 5 workers for xatu_output_stdout_bn_74191  module=contributoor trace_id=bn_74191
INFO[0000] Starting 1 workers for xatu_output_xatu_bn_74191  module=contributoor trace_id=bn_74191
INFO[0000] Beacon connected successfully                 module=contributoor trace_id=bn_74191
INFO[0000] Subscribing to events upstream                module=contributoor topics="[block head finalized_checkpoint blob_sidecar chain_reorg]" trace_id=bn_74191
INFO[0000] Deriving ethereum network                     config_name=mainnet deposit_chain_id=1 deposit_contract_address=0x00000000219ab540356cbb839cbe05303d7705fa module=sentry/ethereum/metadata trace_id=bn_74191
INFO[0000] Detected network and node ID hash             hash=56155f307e module=contributoor network=mainnet network_id=1 node_id=56155f307e trace_id=bn_74191
INFO[0001] Starting summary                              interval=10s module=contributoor trace_id=bn_74191
```

