### PR TITLE
build(codecov): disable codecov comments and GitHub checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,10 @@
+comment: false
+github_checks:
+  annotations: false
+coverage:
+  status:
+    project: off
+    patch: off
 ignore:
   - ".github"
   - "README.md"


### PR DESCRIPTION
Disables the automatic commenting and GitHub checks from Codecov. This change is made to reduce noise in pull requests and rely solely on the status checks provided by the CI/CD pipeline.