### PR TITLE
feat: add SubnetHighWaterMark to tolerate temporary subnet participation

### DIFF
--- a/pkg/application/beacons.go
+++ b/pkg/application/beacons.go
@@ -179,6 +179,7 @@ func (a *Application) createTopicManager(ctx context.Context, log logrus.FieldLo
 		MismatchDetectionWindow: config.AttestationSubnetConfig.MismatchDetectionWindow,
 		MismatchThreshold:       config.AttestationSubnetConfig.MismatchThreshold,
 		MismatchCooldown:        time.Duration(config.AttestationSubnetConfig.MismatchCooldownSeconds) * time.Second,
+		SubnetHighWaterMark:     config.AttestationSubnetConfig.SubnetHighWaterMark,
 	})
 
 	// Check for attestation subnet participation if enabled

--- a/pkg/ethereum/config.go
+++ b/pkg/ethereum/config.go
@@ -30,6 +30,10 @@ type SubnetConfig struct {
 	MismatchThreshold int `yaml:"mismatchThreshold"`
 	// MismatchCooldownSeconds is the cooldown period between reconnections in seconds.
 	MismatchCooldownSeconds int `yaml:"mismatchCooldownSeconds"`
+	// SubnetHighWaterMark allows temporary participation in additional subnets
+	// without triggering a restart. This accommodates validators temporarily
+	// joining subnets to submit attestations while protecting privacy.
+	SubnetHighWaterMark int `yaml:"subnetHighWaterMark"`
 }
 
 // NewDefaultConfig returns a new config with default values.
@@ -41,6 +45,7 @@ func NewDefaultConfig() *Config {
 			MismatchDetectionWindow: 2,   // 2 slots for testing
 			MismatchThreshold:       2,   // Lower threshold for testing
 			MismatchCooldownSeconds: 300, // 5 minutes
+			SubnetHighWaterMark:     5,   // Allow up to 5 additional temporary subnets
 		},
 	}
 }


### PR DESCRIPTION
This PR implements a high water mark threshold mechanism to prevent false-positive beacon node restarts caused by validators temporarily joining attestation subnets. The feature protects validator privacy by only exporting attestations from advertised subnets while allowing temporary participation in additional subnets without triggering unnecessary reconnections.

  Problem

Previously, Contributoor would restart the beacon connection whenever it detected attestations from any non-advertised subnet. This caused issues because:
- Validators temporarily join subnets to submit their own attestations
- These temporary participations would be incorrectly flagged as misconfigurations
- A false-positive restart would then disrupt normal operations
- Exporting low-volume attestations from non-advertised subnets could reveal validator ownership

Implemented a configurable high water mark threshold that:
- Allows validators to temporarily participate in up to N additional subnets (default: 5)
- Only triggers reconnection when non-advertised subnet count exceeds the threshold
- Maintains privacy by continuing to filter attestations - only forwarding those from advertised subnets

<details>
  <summary>Show Logs</summary>

```bash
INFO[0039] All services are ready                        module=ethcore/ethereum/beacon
INFO[0039] Event subscriptions setup successfully        module=contributoor
INFO[0039] Beacon connected successfully                 module=contributoor trace_id=e1c9yeX2
INFO[0039] Application started successfully              module=contributoor
WARN[0039] Approaching subnet high water mark threshold  advertised_subnets="[19 20]" component=topic_manager high_water_mark=5 module=contributoor non_advertised_count=4 trace_id=e1c9yeX2
WARN[0039] Approaching subnet high water mark threshold  advertised_subnets="[19 20]" component=topic_manager high_water_mark=5 module=contributoor non_advertised_count=4 trace_id=e1c9yeX2
WARN[0039] Approaching subnet high water mark threshold  advertised_subnets="[19 20]" component=topic_manager high_water_mark=5 module=contributoor non_advertised_count=5 trace_id=e1c9yeX2
WARN[0039] Subnet mismatch detected                      advertised_subnets="[19 20]" component=topic_manager mismatch_count=1 module=contributoor seen_subnets="[31 8 21 19 10 3 15]" threshold=2 trace_id=e1c9yeX2
WARN[0039] Restarting beacon                             module=contributoor trace_id=e1c9yeX2
INFO[0039] Stopping beacon node                          module=ethcore/ethereum/beacon
INFO[0039] Stopping service                              module=ethcore/ethereum/beacon service=metadata
INFO[0039] Stopping xatu sink                            module=contributoor trace_id=e1c9yeX2
```
</details>