### PR TITLE
fix(beacons): sink lifecycle

### DIFF
--- a/pkg/application/sinks.go
+++ b/pkg/application/sinks.go
@@ -8,8 +8,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// initSinks creates and starts the event sinks based on configuration.
+// initSinks creates the event sinks based on configuration.
 // In debug mode, it uses stdout sink. Otherwise, it creates the configured output sink.
+// Note: Sinks are started by the BeaconWrapper when the beacon node starts.
 func (a *Application) initSinks(ctx context.Context, log logrus.FieldLogger, traceID string) ([]sinks.ContributoorSink, error) {
 	eventSinks := make([]sinks.ContributoorSink, 0)
 
@@ -20,10 +21,6 @@ func (a *Application) initSinks(ctx context.Context, log logrus.FieldLogger, tra
 			return nil, fmt.Errorf("failed to create stdout sink: %w", err)
 		}
 
-		if err := stdoutSink.Start(ctx); err != nil {
-			return nil, fmt.Errorf("failed to start stdout sink: %w", err)
-		}
-
 		eventSinks = append(eventSinks, stdoutSink)
 
 		log.Info("Using stdout sink (debug mode)")
@@ -32,10 +29,6 @@ func (a *Application) initSinks(ctx context.Context, log logrus.FieldLogger, tra
 		xatuSink, err := sinks.NewXatuSink(log, a.config, traceID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create xatu sink: %w", err)
-		}
-
-		if err := xatuSink.Start(ctx); err != nil {
-			return nil, fmt.Errorf("failed to start xatu sink: %w", err)
 		}
 
 		eventSinks = append(eventSinks, xatuSink)


### PR DESCRIPTION
fix(beacons): assign new sinks and cache to prevent nil references
refactor(sinks): remove manual sink starts, rely on BeaconWrapper
docs(beacons): clarify that old sinks are stopped and replaced