### PR TITLE
fix(node_identity): correct attnets bitmask bit-ordering from MSB to LSB

### DIFF
--- a/pkg/ethereum/node_identity_test.go
+++ b/pkg/ethereum/node_identity_test.go
@@ -2,6 +2,7 @@ package ethereum_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -199,4 +200,153 @@ func TestNodeIdentity_GetAttnets(t *testing.T) {
 			assert.Equal(t, tt.expectedSubnets, subnets)
 		})
 	}
+}
+
+func TestParseAttnetsBitmask(t *testing.T) {
+	tests := []struct {
+		name     string
+		attnets  string
+		expected []int
+	}{
+		{
+			name:     "empty attnets",
+			attnets:  "0x0000000000000000",
+			expected: nil, // ParseAttnetsBitmask returns nil for empty, not []int{}
+		},
+		{
+			name:     "single subnet 0",
+			attnets:  "0x0100000000000000",
+			expected: []int{0},
+		},
+		{
+			name:     "single subnet 7",
+			attnets:  "0x8000000000000000",
+			expected: []int{7},
+		},
+		{
+			name:     "single subnet 8",
+			attnets:  "0x0001000000000000",
+			expected: []int{8},
+		},
+		{
+			name:     "single subnet 52",
+			attnets:  "0x0000000000001000",
+			expected: []int{52},
+		},
+		{
+			name:     "single subnet 53",
+			attnets:  "0x0000000000002000",
+			expected: []int{53},
+		},
+		{
+			name:     "subnets 50 and 51 (0x0c = 0b00001100 in byte 6, LSB-first)",
+			attnets:  "0x0000000000000c00",
+			expected: []int{50, 51},
+		},
+		{
+			name:     "subnets 52 and 53 (0x30 = 0b00110000 in byte 6, LSB-first)",
+			attnets:  "0x0000000000003000",
+			expected: []int{52, 53},
+		},
+		{
+			name:     "multiple subnets in first byte (0, 1, 7)",
+			attnets:  "0x8300000000000000",
+			expected: []int{0, 1, 7},
+		},
+		{
+			name:     "subnets across multiple bytes",
+			attnets:  "0x0303000000000000",
+			expected: []int{0, 1, 8, 9},
+		},
+		{
+			name:     "all subnets in first byte",
+			attnets:  "0xff00000000000000",
+			expected: []int{0, 1, 2, 3, 4, 5, 6, 7},
+		},
+		{
+			name:     "with 0x prefix",
+			attnets:  "0x0100000000000000",
+			expected: []int{0},
+		},
+		{
+			name:     "without 0x prefix",
+			attnets:  "0100000000000000",
+			expected: []int{0},
+		},
+		{
+			name:     "real example - subnets 46 and 47",
+			attnets:  "0x0000000000c00000",
+			expected: []int{46, 47},
+		},
+		{
+			name:     "max subnet 63",
+			attnets:  "0x0000000000000080",
+			expected: []int{63},
+		},
+		{
+			name:     "test MSB vs LSB - 0x01 should be subnet 0, not subnet 7",
+			attnets:  "0x0100000000000000",
+			expected: []int{0}, // LSB-first: bit 0
+		},
+		{
+			name:     "test MSB vs LSB - 0x80 should be subnet 7, not subnet 0",
+			attnets:  "0x8000000000000000",
+			expected: []int{7}, // LSB-first: bit 7
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ethereum.ParseAttnetsBitmask(tt.attnets)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseAttnetsBitmask_Error(t *testing.T) {
+	tests := []struct {
+		name    string
+		attnets string
+	}{
+		{
+			name:    "invalid hex",
+			attnets: "0xgggggggggggggggg",
+		},
+		{
+			name:    "odd length hex",
+			attnets: "0x123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ethereum.ParseAttnetsBitmask(tt.attnets)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestParseAttnetsBitmask_BitOrdering(t *testing.T) {
+	// This test specifically verifies LSB-first bit ordering
+	// to ensure the fix for the MSB/LSB issue doesn't regress
+
+	// Test each bit position in a byte
+	for bitPos := 0; bitPos < 8; bitPos++ {
+		// Create a bitmask with only one bit set
+		byteValue := byte(1 << bitPos)
+		attnets := fmt.Sprintf("0x%02x00000000000000", byteValue)
+
+		result, err := ethereum.ParseAttnetsBitmask(attnets)
+		require.NoError(t, err)
+		require.Len(t, result, 1, "Expected exactly one subnet for bit %d", bitPos)
+		assert.Equal(t, bitPos, result[0], "Bit %d should map to subnet %d", bitPos, bitPos)
+	}
+
+	// Test that 0x0c (0b00001100) in byte 6 gives subnets 50 and 51
+	// This was the actual bug case from the logs where beacon advertised [52, 53]
+	// but we incorrectly parsed 0x0000000000000c00 as [52, 53] instead of [50, 51]
+	result, err := ethereum.ParseAttnetsBitmask("0x0000000000000c00")
+	require.NoError(t, err)
+	assert.Equal(t, []int{50, 51}, result, "0x0c in byte 6 should be subnets 50 and 51 (LSB-first), not 52 and 53 (MSB-first)")
 }


### PR DESCRIPTION
fixes absolute cbt