### PR TITLE
feat(beacon): add periodic refresh of advertised attestation subnets

### DIFF
--- a/pkg/ethereum/beacon.go
+++ b/pkg/ethereum/beacon.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"sync/atomic"
+	"time"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/electra"
@@ -65,13 +66,40 @@ func (w *BeaconWrapper) Start(ctx context.Context) error {
 	}
 
 	// The upstream Start() is now blocking and waits until the node is ready.
-	return w.BeaconNode.Start(ctx)
+	if err := w.BeaconNode.Start(ctx); err != nil {
+		return err
+	}
+
+	// Start subnet refresh if attestation subnet tracking is enabled
+	if w.config.AttestationSubnetConfig.Enabled && w.topicManager != nil {
+		// Create a fetcher function that gets the current attnets
+		fetcher := func() []int {
+			identity := NewNodeIdentity(w.log, w.config.BeaconNodeAddress, w.config.BeaconNodeHeaders)
+			if err := identity.Start(ctx); err != nil {
+				w.log.WithError(err).Debug("Failed to fetch node identity during refresh")
+
+				return nil
+			}
+
+			return identity.GetAttnets()
+		}
+
+		// Start refreshing every 30 seconds
+		w.topicManager.StartSubnetRefresh(ctx, 30*time.Second, fetcher)
+	}
+
+	return nil
 }
 
 // Stop to handle sink lifecycle.
 func (w *BeaconWrapper) Stop(ctx context.Context) error {
 	// Mark as unhealthy to prevent health check logs
 	w.isHealthy.Store(false)
+
+	// Stop subnet refresh if it's running
+	if w.topicManager != nil {
+		w.topicManager.StopSubnetRefresh()
+	}
 
 	// Stop upstream first.
 	if err := w.BeaconNode.Stop(ctx); err != nil {

--- a/pkg/ethereum/beacon.go
+++ b/pkg/ethereum/beacon.go
@@ -155,8 +155,6 @@ func (w *BeaconWrapper) setupEventSubscriptions(ctx context.Context) error {
 					// the mismatch detection will catch it when we receive attestations
 					// from the old subnets that are no longer advertised
 					w.topicManager.SetAdvertisedSubnets(newSubnets)
-
-					w.log.WithField("subnets", newSubnets).Info("Updated attestation subnets after reconnection")
 				}
 			}
 		}

--- a/pkg/ethereum/mock/topic_manager.mock.go
+++ b/pkg/ethereum/mock/topic_manager.mock.go
@@ -186,3 +186,27 @@ func (mr *MockTopicManagerMockRecorder) ShouldSubscribe(ctx, topic any) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSubscribe", reflect.TypeOf((*MockTopicManager)(nil).ShouldSubscribe), ctx, topic)
 }
+
+// StartSubnetRefresh mocks base method.
+func (m *MockTopicManager) StartSubnetRefresh(ctx context.Context, refreshInterval time.Duration, nodeIdentityFetcher func() []int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "StartSubnetRefresh", ctx, refreshInterval, nodeIdentityFetcher)
+}
+
+// StartSubnetRefresh indicates an expected call of StartSubnetRefresh.
+func (mr *MockTopicManagerMockRecorder) StartSubnetRefresh(ctx, refreshInterval, nodeIdentityFetcher any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartSubnetRefresh", reflect.TypeOf((*MockTopicManager)(nil).StartSubnetRefresh), ctx, refreshInterval, nodeIdentityFetcher)
+}
+
+// StopSubnetRefresh mocks base method.
+func (m *MockTopicManager) StopSubnetRefresh() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "StopSubnetRefresh")
+}
+
+// StopSubnetRefresh indicates an expected call of StopSubnetRefresh.
+func (mr *MockTopicManagerMockRecorder) StopSubnetRefresh() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopSubnetRefresh", reflect.TypeOf((*MockTopicManager)(nil).StopSubnetRefresh))
+}


### PR DESCRIPTION
Introduce StartSubnetRefresh and StopSubnetRefresh to the TopicManager interface and implementation. 

When attestation subnet tracking is enabled, BeaconWrapper now spawns a goroutine that fetches the current attnets from the beacon node every 30 seconds and updates the advertised subnet list if it has changed. 

This keeps the advertised subnets in sync with the actual node configuration without requiring a restart.