### PR TITLE
feat(sentry): add attestation subnet mismatch detection and reconnection tuning flags

### DIFF
--- a/cmd/sentry/config.go
+++ b/cmd/sentry/config.go
@@ -258,5 +258,153 @@ func applyAttestationSubnetConfig(cfg *config.Config, c *cli.Context) error {
 		cfg.AttestationSubnetCheck.MaxSubnets = uint32(c.Int("attestation-subnet-max-subnets")) //nolint:gosec // conversion fine.
 	}
 
+	// Handle mismatch detection window
+	if err := applyMismatchDetectionWindow(cfg, c); err != nil {
+		return err
+	}
+
+	// Handle mismatch threshold
+	if err := applyMismatchThreshold(cfg, c); err != nil {
+		return err
+	}
+
+	// Handle mismatch cooldown
+	if err := applyMismatchCooldown(cfg, c); err != nil {
+		return err
+	}
+
+	// Handle subnet high water mark
+	if err := applySubnetHighWaterMark(cfg, c); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// applyMismatchDetectionWindow applies mismatch detection window configuration.
+func applyMismatchDetectionWindow(cfg *config.Config, c *cli.Context) error {
+	// Handle env var
+	if window := os.Getenv("CONTRIBUTOOR_ATTESTATION_SUBNET_MISMATCH_DETECTION_WINDOW"); window != "" {
+		log.Infof("Setting attestation subnet mismatch detection window from env to %s", window)
+
+		windowInt, err := strconv.ParseUint(window, 10, 32)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse attestation subnet mismatch detection window env var")
+		}
+
+		if cfg.AttestationSubnetCheck == nil {
+			cfg.AttestationSubnetCheck = &config.AttestationSubnetCheck{}
+		}
+
+		cfg.AttestationSubnetCheck.MismatchDetectionWindow = uint32(windowInt)
+	}
+
+	// CLI flag overrides env var
+	if c.Int("attestation-subnet-mismatch-detection-window") >= 0 { // -1 means not set
+		log.Infof("Setting attestation subnet mismatch detection window from CLI to %d", c.Int("attestation-subnet-mismatch-detection-window"))
+
+		if cfg.AttestationSubnetCheck == nil {
+			cfg.AttestationSubnetCheck = &config.AttestationSubnetCheck{}
+		}
+
+		cfg.AttestationSubnetCheck.MismatchDetectionWindow = uint32(c.Int("attestation-subnet-mismatch-detection-window")) //nolint:gosec // conversion fine.
+	}
+
+	return nil
+}
+
+// applyMismatchThreshold applies mismatch threshold configuration.
+func applyMismatchThreshold(cfg *config.Config, c *cli.Context) error {
+	// Handle env var
+	if threshold := os.Getenv("CONTRIBUTOOR_ATTESTATION_SUBNET_MISMATCH_THRESHOLD"); threshold != "" {
+		log.Infof("Setting attestation subnet mismatch threshold from env to %s", threshold)
+
+		thresholdInt, err := strconv.ParseUint(threshold, 10, 32)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse attestation subnet mismatch threshold env var")
+		}
+
+		if cfg.AttestationSubnetCheck == nil {
+			cfg.AttestationSubnetCheck = &config.AttestationSubnetCheck{}
+		}
+
+		cfg.AttestationSubnetCheck.MismatchThreshold = uint32(thresholdInt)
+	}
+
+	// CLI flag overrides env var
+	if c.Int("attestation-subnet-mismatch-threshold") >= 0 { // -1 means not set
+		log.Infof("Setting attestation subnet mismatch threshold from CLI to %d", c.Int("attestation-subnet-mismatch-threshold"))
+
+		if cfg.AttestationSubnetCheck == nil {
+			cfg.AttestationSubnetCheck = &config.AttestationSubnetCheck{}
+		}
+
+		cfg.AttestationSubnetCheck.MismatchThreshold = uint32(c.Int("attestation-subnet-mismatch-threshold")) //nolint:gosec // conversion fine.
+	}
+
+	return nil
+}
+
+// applyMismatchCooldown applies mismatch cooldown configuration.
+func applyMismatchCooldown(cfg *config.Config, c *cli.Context) error {
+	// Handle env var
+	if cooldown := os.Getenv("CONTRIBUTOOR_ATTESTATION_SUBNET_MISMATCH_COOLDOWN_SECONDS"); cooldown != "" {
+		log.Infof("Setting attestation subnet mismatch cooldown from env to %s seconds", cooldown)
+
+		cooldownInt, err := strconv.ParseUint(cooldown, 10, 32)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse attestation subnet mismatch cooldown env var")
+		}
+
+		if cfg.AttestationSubnetCheck == nil {
+			cfg.AttestationSubnetCheck = &config.AttestationSubnetCheck{}
+		}
+
+		cfg.AttestationSubnetCheck.MismatchCooldownSeconds = uint32(cooldownInt)
+	}
+
+	// CLI flag overrides env var
+	if c.Int("attestation-subnet-mismatch-cooldown-seconds") >= 0 { // -1 means not set
+		log.Infof("Setting attestation subnet mismatch cooldown from CLI to %d seconds", c.Int("attestation-subnet-mismatch-cooldown-seconds"))
+
+		if cfg.AttestationSubnetCheck == nil {
+			cfg.AttestationSubnetCheck = &config.AttestationSubnetCheck{}
+		}
+
+		cfg.AttestationSubnetCheck.MismatchCooldownSeconds = uint32(c.Int("attestation-subnet-mismatch-cooldown-seconds")) //nolint:gosec // conversion fine.
+	}
+
+	return nil
+}
+
+// applySubnetHighWaterMark applies subnet high water mark configuration.
+func applySubnetHighWaterMark(cfg *config.Config, c *cli.Context) error {
+	// Handle env var
+	if watermark := os.Getenv("CONTRIBUTOOR_ATTESTATION_SUBNET_HIGH_WATER_MARK"); watermark != "" {
+		log.Infof("Setting attestation subnet high water mark from env to %s", watermark)
+
+		watermarkInt, err := strconv.ParseUint(watermark, 10, 32)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse attestation subnet high water mark env var")
+		}
+
+		if cfg.AttestationSubnetCheck == nil {
+			cfg.AttestationSubnetCheck = &config.AttestationSubnetCheck{}
+		}
+
+		cfg.AttestationSubnetCheck.SubnetHighWaterMark = uint32(watermarkInt)
+	}
+
+	// CLI flag overrides env var
+	if c.Int("attestation-subnet-high-water-mark") >= 0 { // -1 means not set
+		log.Infof("Setting attestation subnet high water mark from CLI to %d", c.Int("attestation-subnet-high-water-mark"))
+
+		if cfg.AttestationSubnetCheck == nil {
+			cfg.AttestationSubnetCheck = &config.AttestationSubnetCheck{}
+		}
+
+		cfg.AttestationSubnetCheck.SubnetHighWaterMark = uint32(c.Int("attestation-subnet-high-water-mark")) //nolint:gosec // conversion fine.
+	}
+
 	return nil
 }

--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -116,6 +116,30 @@ func main() {
 				Value:    -1, // -1 indicates not set via CLI
 				Required: false,
 			},
+			&cli.IntFlag{
+				Name:     "attestation-subnet-mismatch-detection-window",
+				Usage:    "number of slots to track for subnet activity",
+				Value:    -1, // -1 indicates not set via CLI
+				Required: false,
+			},
+			&cli.IntFlag{
+				Name:     "attestation-subnet-mismatch-threshold",
+				Usage:    "number of mismatches required before triggering reconnection",
+				Value:    -1, // -1 indicates not set via CLI
+				Required: false,
+			},
+			&cli.IntFlag{
+				Name:     "attestation-subnet-mismatch-cooldown-seconds",
+				Usage:    "cooldown period between reconnections in seconds",
+				Value:    -1, // -1 indicates not set via CLI
+				Required: false,
+			},
+			&cli.IntFlag{
+				Name:     "attestation-subnet-high-water-mark",
+				Usage:    "number of additional temporary subnets allowed without triggering a restart",
+				Value:    -1, // -1 indicates not set via CLI
+				Required: false,
+			},
 			&cli.BoolFlag{
 				Name:     "release",
 				Usage:    "print release and exit",


### PR DESCRIPTION
  1. Via config.yaml:
```
  attestationSubnetCheck:
    enabled: true
    maxSubnets: 2
    mismatchDetectionWindow: 32
    mismatchThreshold: 3
    mismatchCooldownSeconds: 300
    subnetHighWaterMark: 5
```
  2. Via Environment Variables:
```
  export CONTRIBUTOOR_ATTESTATION_SUBNET_CHECK_ENABLED=true
  export CONTRIBUTOOR_ATTESTATION_SUBNET_MAX_SUBNETS=2
  export CONTRIBUTOOR_ATTESTATION_SUBNET_MISMATCH_DETECTION_WINDOW=32
  export CONTRIBUTOOR_ATTESTATION_SUBNET_MISMATCH_THRESHOLD=3
  export CONTRIBUTOOR_ATTESTATION_SUBNET_MISMATCH_COOLDOWN_SECONDS=300
  export CONTRIBUTOOR_ATTESTATION_SUBNET_HIGH_WATER_MARK=5
```
  3. Via CLI Arguments:

```
  go run ./cmd/sentry \
    --attestation-subnet-check-enabled \
    --attestation-subnet-max-subnets 2 \
    --attestation-subnet-mismatch-detection-window 32 \
    --attestation-subnet-mismatch-threshold 3 \
    --attestation-subnet-mismatch-cooldown-seconds 300 \
    --attestation-subnet-high-water-mark 5
```